### PR TITLE
Remove default autofocus

### DIFF
--- a/src/Components/Suggestion/index.jsx
+++ b/src/Components/Suggestion/index.jsx
@@ -114,6 +114,7 @@ const Suggestion = (props) => {
             value={dropdownOptions.filter(option => option.value === stateAbbr)}
             onChange={value => onDropdownChange(value)}
             isSearchable={true}
+            autoFocus={false}
           />
         </div>
       }


### PR DESCRIPTION
This PR is to remove the default autofocus on the `<Select/>` dropdown -- https://react-select.com/. I think that this will help with the issue of the keyboard popping up on mobile devices viewing this app in the browser. 